### PR TITLE
Add character counters to post and comment inputs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -205,12 +205,31 @@ button:hover {
   gap: 10px;
 }
 
-.comment-form input {
+.comment-input-wrapper {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.comment-form input {
+  width: 100%;
   padding: 8px 12px;
   border: 1px solid #ddd;
   border-radius: 4px;
   font-family: inherit;
+  box-sizing: border-box;
+}
+
+.char-counter {
+  font-size: 0.75em;
+  color: #999;
+  text-align: right;
+}
+
+.char-counter-warning {
+  color: #e67e22;
+  font-weight: 500;
 }
 
 /* Responsive Design */

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -180,6 +180,9 @@ function App() {
                   rows={4}
                   maxLength={MAX_POST_LENGTH}
                 />
+                <span className={`char-counter ${newPost.length >= MAX_POST_LENGTH * 0.9 ? 'char-counter-warning' : ''}`}>
+                  {newPost.length}/{MAX_POST_LENGTH}
+                </span>
                 <div className="post-form-buttons">
                   <button type="submit">Post Message</button>
                   <button
@@ -323,13 +326,18 @@ function CommentSection({ postId, fetchPosts }) {
           </div>
 
           <form onSubmit={handleSubmitComment} className="comment-form">
-            <input
-              type="text"
-              value={newComment}
-              onChange={(e) => setNewComment(e.target.value)}
-              placeholder="Add a comment..."
-              maxLength={MAX_COMMENT_LENGTH}
-            />
+            <div className="comment-input-wrapper">
+              <input
+                type="text"
+                value={newComment}
+                onChange={(e) => setNewComment(e.target.value)}
+                placeholder="Add a comment..."
+                maxLength={MAX_COMMENT_LENGTH}
+              />
+              <span className={`char-counter ${newComment.length >= MAX_COMMENT_LENGTH * 0.9 ? 'char-counter-warning' : ''}`}>
+                {newComment.length}/{MAX_COMMENT_LENGTH}
+              </span>
+            </div>
             <button type="submit">Comment</button>
           </form>
         </>


### PR DESCRIPTION
Display current/max character counts below the post textarea and comment
input. Counter turns orange when usage reaches 90% of the limit, giving
users clear feedback before hitting the hard maxLength cap.

https://claude.ai/code/session_01CsDfBxXbrx6AxFQdNvZa3P